### PR TITLE
be precise when clients can clear the QUIC bits based on the value of the token

### DIFF
--- a/draft-ietf-quic-bit-grease.md
+++ b/draft-ietf-quic-bit-grease.md
@@ -95,7 +95,7 @@ receiving and processing transport parameters are affected, including Retry,
 Initial, and Handshake packets.
 
 A client MAY also clear the QUIC Bit in Initial packets that are sent prior to
-receiving the transport parameters.  A client can only clear the QUIC Bit if
+receiving transport parameters from the server.  A client can only clear the QUIC Bit if
 such packets include a token provided by the server in a NEW_TOKEN frame on a
 connection where the server also included the grease_quic_bit transport
 parameter.  To allow for changes in server configuration, clients SHOULD set

--- a/draft-ietf-quic-bit-grease.md
+++ b/draft-ietf-quic-bit-grease.md
@@ -94,12 +94,12 @@ assigns specific meaning to the value of the bit.  All packets sent after
 receiving and processing transport parameters are affected, including Retry,
 Initial, and Handshake packets.
 
-A client MAY also clear the QUIC Bit in Initial packets that are sent to
-establish a new connection. A client can only clear the QUIC Bit if the packet
-includes a token provided by the server in a NEW_TOKEN frame on a connection
-where the server also included the grease_quic_bit transport parameter.  To
-allow for changes in server configuration, clients SHOULD set the QUIC Bit if
-the token was provided more than 7 days prior.
+A client MAY also clear the QUIC Bit in Initial packets that are sent prior to
+receiving the transport parameters.  A client can only clear the QUIC Bit if
+such packets include a token provided by the server in a NEW_TOKEN frame on a
+connection where the server also included the grease_quic_bit transport
+parameter.  To allow for changes in server configuration, clients SHOULD set
+the QUIC Bit if the token was provided more than 7 days prior.
 
 
 ## Using the QUIC Bit


### PR DESCRIPTION
At the moment, the paragraph says "Initial packets that are sent to establish a new connection." That is unclear. It is possible to interpret this text as "all Initial packets that the client sends," because all the Initial packets are used to establish a new connection.

As the paragraph right above discusses what endpoints should do once they receive transport parameters, we can be clear that this paragraph discusses what should be done until then.