### PR TITLE
Editorial clarification

### DIFF
--- a/draft-ietf-quic-bit-grease.md
+++ b/draft-ietf-quic-bit-grease.md
@@ -90,16 +90,21 @@ current handshake is used to determine what values can be sent in the QUIC Bit.
 Endpoints that receive the grease_quic_bit transport parameter from a peer MAY
 set the QUIC Bit to any value in packets they send to that peer.  Endpoints
 SHOULD set the QUIC Bit to an unpredictable value unless another extension
-assigns specific meaning to the value of the bit.  All packets sent after
-receiving and processing transport parameters are affected, including Retry,
-Initial, and Handshake packets.
+assigns specific meaning to the value of the bit.
+
+All packets sent after receiving and processing transport parameters might be
+affected, including Initial, Handshake, and Retry packets.
 
 A client MAY also clear the QUIC Bit in Initial packets that are sent prior to
-receiving transport parameters from the server.  A client can only clear the QUIC Bit if
-such packets include a token provided by the server in a NEW_TOKEN frame on a
-connection where the server also included the grease_quic_bit transport
-parameter.  To allow for changes in server configuration, clients SHOULD set
-the QUIC Bit if the token was provided more than 7 days prior.
+receiving transport parameters from the server.  A client can only clear the
+QUIC Bit if such packets include a token provided by the server in a NEW_TOKEN
+frame on a connection where the server also included the grease_quic_bit
+transport parameter.  To allow for changes in server configuration, clients
+SHOULD set the QUIC Bit if the token was provided more than 7 days prior.
+
+A server MUST clear the QUIC bit only after processing transport parameters from
+a client.  A server cannot remember that a client negotiated the extension in a
+previous connection and clear the QUIC Bit based on that information.
 
 
 ## Using the QUIC Bit

--- a/draft-ietf-quic-bit-grease.md
+++ b/draft-ietf-quic-bit-grease.md
@@ -106,6 +106,11 @@ A server MUST clear the QUIC bit only after processing transport parameters from
 a client.  A server cannot remember that a client negotiated the extension in a
 previous connection and clear the QUIC Bit based on that information.
 
+An endpoint cannot clear the QUIC Bit without knowing whether the peer supports
+the extension.  As stateless reset packets ({{Section 10.3 of QUIC}}) are only
+used after a loss of connection state, endpoints are unlikely to be able to
+clear the QUIC Bit on stateless reset packets.
+
 
 ## Using the QUIC Bit
 

--- a/draft-ietf-quic-bit-grease.md
+++ b/draft-ietf-quic-bit-grease.md
@@ -116,16 +116,12 @@ Extensions to QUIC that define semantics for the QUIC Bit can be negotiated at
 the same time as the grease_quic_bit transport parameter.  In this case, a
 recipient needs to be able to distinguish a randomized value from a value
 carrying information according to the extension.  Extensions that use the QUIC
-Bit MUST negotiate their use prior to acting on any semantic.  Endpoints MAY
-send a signal prior to this negotiation completing, but any value carried by the
-bit cannot be used until it is clear that the peer is using the extension.
+Bit MUST negotiate their use prior to acting on any semantic.
 
 For example, an extension might define a transport parameter that is sent in
 addition to the grease_quic_bit transport parameter.  Though the value of the
 QUIC Bit in packets received by a peer might be set according to rules defined
 by the extension, they might also be randomized as specified in this document.
-Including both extensions allows for the QUIC Bit to be greased even if the
-alternative use is not supported.
 
 Receiving a transport parameter for an extension that uses the QUIC Bit could be
 used to confirm that a peer supports the semantic defined in the extension.  To
@@ -135,7 +131,9 @@ the information conveyed until the transport parameter for the extension is
 received.
 
 Extensions that define semantics for the QUIC Bit can be negotiated without
-using the grease_quic_bit transport parameter.
+using the grease_quic_bit transport parameter.  However, including both
+extensions allows for the QUIC Bit to be greased even if the alternative use is
+not supported.
 
 
 # Security Considerations


### PR DESCRIPTION
It seems like the answer to #13 was already in the draft.  It just wasn't precise enough to be useful.

I also found the wording of the next section awkward, so I'm bundling my changes.